### PR TITLE
updating configureLTPAKeys()

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -8038,9 +8038,9 @@ public class LibertyServer implements LogMonitorClient {
         return envVars.get(var);
     }
 
-    public void configureLTPAKeys(JavaInfo info) throws IOException, InterruptedException {
+    private void configureLTPAKeys(JavaInfo info) throws IOException, InterruptedException {
 
-        if (isFIPS140_3EnabledAndSupported()) {
+        if (isFIPS140_3EnabledAndSupported(info)) {
             String serverSecurityDir = serverRoot + File.separator + "resources" + File.separator + "security";
             File ltpaFIPSKeys = new File(serverSecurityDir, "ltpaFIPS.keys");
             File ltpaKeys = new File(serverSecurityDir, "ltpa.keys");
@@ -8072,7 +8072,7 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     
-    private void configureLTPAKeys() throws IOException, InterruptedException {
+    public void configureLTPAKeys() throws IOException, InterruptedException {
         configureLTPAKeys(JavaInfo.forServer(this));
     }
 


### PR DESCRIPTION
it looks like a commit was missing or a mistake was made when merging in LIbertyServer.java. The public method doesn't use the inputted JavaInfo object . I updated it to use that object and then made the other method public which was the original intention. 