### PR TITLE
removing duplicates from JVM_ARGS

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1732,8 +1732,9 @@ public class LibertyServer implements LogMonitorClient {
             // TODO: `getJvmOptionsAsMap()` should be added to JVM_ARGS outside of this if-block so that we always run it.
             // During FIPS 140-3 development, we found test scenarios where jvm.options is set before server start and the file is ignored.
             // So that we can test FIPS 140-3 without causing issues unrelated to FIPS, we have put it inside this if-block, for now.
-            JVM_ARGS += getJvmArgString(this.getJvmOptionsAsMap());
-            JVM_ARGS += getJvmArgString(this.getFipsJvmOptions(info, false));
+            Map<String, String> combined = this.getJvmOptionsAsMap();
+            combined.putAll(this.getFipsJvmOptions(info, false));
+            JVM_ARGS += getJvmArgString(combined);
         }
 
         Properties bootstrapProperties = getBootstrapProperties();


### PR DESCRIPTION
This will prevent duplicates that were already in jvm.options from being added to JVM_ARGS afterwards. I don't think this is necessarily 