### PR TITLE
Jd update aes 128 bit secrets to 256 bit in tests that run fips

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/server.xml
@@ -71,7 +71,7 @@
     </adminObject>
 
     <!-- "APP" is the default schema for Derby -->
-    <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
+    <authData id="APP" user="APP" password="{aes}ARAM+spFSyffcLzRa7yFumadNtLCSyfySk98jjDJ/lR5x4P9ipHU/rei/9W0e0BrjWO0sJLNNLP5EXIArLhAjiT4UATmFDvuQ0cLRcci0483AtbzNOP+dP0IcLd0LWJV+/oCSVVR4LzP"/>
 
     <application type="ear" id="derbyRAApp" location="derbyRAApp.ear"/>
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
@@ -48,7 +48,7 @@
     </jaasLoginContextEntry>
 
     <!-- "APP" is the default schema for Derby -->
-    <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
+    <authData id="APP" user="APP" password="{aes}ARAM+spFSyffcLzRa7yFumadNtLCSyfySk98jjDJ/lR5x4P9ipHU/rei/9W0e0BrjWO0sJLNNLP5EXIArLhAjiT4UATmFDvuQ0cLRcci0483AtbzNOP+dP0IcLd0LWJV+/oCSVVR4LzP"/>
 
     <!-- TODO go through these copied permissions once we are properly loading the login module from the resource adapter -->
     <!-- 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.security/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.security/server.xml
@@ -50,7 +50,7 @@
     </jaasLoginModule>
 
     <!-- "APP" is the default schema for Derby -->
-    <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
+    <authData id="APP" user="APP" password="{aes}ARAM+spFSyffcLzRa7yFumadNtLCSyfySk98jjDJ/lR5x4P9ipHU/rei/9W0e0BrjWO0sJLNNLP5EXIArLhAjiT4UATmFDvuQ0cLRcci0483AtbzNOP+dP0IcLd0LWJV+/oCSVVR4LzP"/>
 
     <application type="ear" id="derbyRAApp" location="derbyRAApp.ear"/>
     

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -70,7 +70,7 @@
     </adminObject>
 
     <!-- "APP" is the default schema for Derby -->
-    <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
+    <authData id="APP" user="APP" password="{aes}ARAM+spFSyffcLzRa7yFumadNtLCSyfySk98jjDJ/lR5x4P9ipHU/rei/9W0e0BrjWO0sJLNNLP5EXIArLhAjiT4UATmFDvuQ0cLRcci0483AtbzNOP+dP0IcLd0LWJV+/oCSVVR4LzP"/>
 
     <application type="ear" id="derbyRAApp" location="derbyRAApp.ear"/>
 

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/myTestClient/configs/client_aesPassword.xml
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/myTestClient/configs/client_aesPassword.xml
@@ -22,7 +22,7 @@
 	<orb id="defaultOrb">
 		<clientPolicy.clientContainerCsiv2>
 			<layers>
-				<authenticationLayer user="user2" password="{aes}ABhZ+C0aVYS5iwMqURMOugh6BNfmzlD+Ko1nRXeUvmVZ" />
+				<authenticationLayer user="user2" password="{aes}ARBy65pibvbPX/1iYmgWRTBNi8Xh1kAKrYlL8F2+2qRT7xRGDTc/GvOjgQs4SyOKmJuY53aMpjtD0YTT4ykbFbD3qKsi5DETQzkc2Qdqi5YdhtQrnhWsFst97XWhqILiWwD94uqXk638eZs=c" />
 				<!-- This is a client configuration file selected to explicitly configure the default SSL config to
 				make sure the default SSL config works when configured explicitly -->
 				<transportLayer sslRef="defaultSSLConfig" />


### PR DESCRIPTION
also added a scenario where we ensure aes 128 bit secrets fail if fips is enabled.